### PR TITLE
Add apply flag to set application icon directly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,13 +19,11 @@ The logic for generating an icon is largely ripped from Ghostty's source code, a
    2. The pre-compiled release is unsigned.[^2]
 2. Run ghostsmith with the required arguments.
 
-Upon running ghostsmith, your custom icon will be saved to the current working directory as `custom-icon.png`, or applied directly to the application when using the `--apply` flag.
+Upon running ghostsmith, your custom icon will be saved to the current working directory as `custom-icon.png`, or applied directly to Ghostty.app when using the `--apply` flag.
 
 [^2]: Reference: ["Open a Mac app from an unknown developer"](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac)
 
 ### Available arguments
-
-`--apply` sets the application icon directly, instead of saving it to the current working directory
 
 `--screen-color` accepts a comma separated list of 1 or more hex color values and/or defined colors\
 *(ex. `--screen-color "black,#ff9dfa"`)*
@@ -34,6 +32,9 @@ Upon running ghostsmith, your custom icon will be saved to the current working d
 *(ex. `--ghost-color X11Purple`)*
 
 `--frame` accepts one of the following options: `aluminum`, `beige`, `plastic`, `chrome`
+
+`--apply` directly applies the icon instead of saving it to the current working directory. ~/Applications/Ghostty.app & /Applications/Ghostty.app are automatically targeted, but a custom path can be supplied\
+*(ex. `--apply "/path/to/Ghostty.app"`)*
 \
 \
 The list of defined colors can be found [here](https://github.com/vandorsx/ghostsmith/blob/main/src/assets/rgb.txt).

--- a/readme.md
+++ b/readme.md
@@ -19,11 +19,13 @@ The logic for generating an icon is largely ripped from Ghostty's source code, a
    2. The pre-compiled release is unsigned.[^2]
 2. Run ghostsmith with the required arguments.
 
-Upon running ghostsmith, your custom icon will be saved to the current working directory as `custom-icon.png`.
+Upon running ghostsmith, your custom icon will be saved to the current working directory as `custom-icon.png`, or applied directly to the application when using the `--apply` flag.
 
 [^2]: Reference: ["Open a Mac app from an unknown developer"](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac)
 
 ### Available arguments
+
+`--apply` sets the application icon directly, instead of saving it to the current working directory
 
 `--screen-color` accepts a comma separated list of 1 or more hex color values and/or defined colors\
 *(ex. `--screen-color "black,#ff9dfa"`)*

--- a/src/ghostsmith.swift
+++ b/src/ghostsmith.swift
@@ -157,7 +157,7 @@ struct ColorizedGhosttyIcon {
     }
 }
 
-// MARK: - Helper Functions
+// MARK: - Generator Helper Functions
 
 // Function to parse the rgb.txt file and create a color dictionary
 func loadColorMap(from fileURL: URL) -> [String: NSColor] {
@@ -245,6 +245,8 @@ func saveImageAsPNG(image: NSImage, filename: String) {
         print("Error saving image: \(error)")
     }
 }
+
+// MARK: - Icon Application Functions
 
 func refreshAppIcon(at targetPath: String) {
     let appURL = URL(fileURLWithPath: targetPath) as CFURL
@@ -356,7 +358,7 @@ struct GhostSmith {
             return
         }
 
-        // Create and save the image
+        // Create icon and save/apply
         let iconGenerator = ColorizedGhosttyIcon(screenColors: screenColors, ghostColor: ghostColor, frame: frame)
         if let icon = iconGenerator.makeImage() {
             if applyIcon || customAppPath != nil {

--- a/src/ghostsmith.swift
+++ b/src/ghostsmith.swift
@@ -246,6 +246,19 @@ func saveImageAsPNG(image: NSImage, filename: String) {
     }
 }
 
+func refreshAppIcon(at appPath: String) {
+    let appURL = URL(fileURLWithPath: appPath) as CFURL
+    let status = LSRegisterURL(appURL, true)
+    if status != noErr {
+        print("Error: Could not refresh icon cache")
+    }
+}
+
+func setAppIcon(_ image: NSImage, appPath: String) {
+    NSWorkspace.shared.setIcon(image, forFile: appPath, options: [])
+    refreshAppIcon(at: appPath)
+}
+
 // MARK: - Main Program Logic
 
 @main
@@ -270,6 +283,7 @@ struct GhostSmith {
         var screenColorStrings: [String] = []
         var ghostColorString: String?
         var frameString: String?
+        var applyIcon: Bool = false
 
         // Parse command line arguments
         let arguments = CommandLine.arguments
@@ -289,6 +303,9 @@ struct GhostSmith {
             case "--frame":
                 frameString = arguments[i + 1]
                 i += 2
+            case "--apply":
+                applyIcon = true
+                i += 1
             default:
                 i += 1
             }
@@ -322,7 +339,11 @@ struct GhostSmith {
         // Create and save the image
         let iconGenerator = ColorizedGhosttyIcon(screenColors: screenColors, ghostColor: ghostColor, frame: frame)
         if let icon = iconGenerator.makeImage() {
-            saveImageAsPNG(image: icon, filename: "custom-icon.png")
+            if applyIcon {
+                setAppIcon(icon, appPath: "/Applications/Ghostty.app")
+            } else {
+                saveImageAsPNG(image: icon, filename: "custom-icon.png")
+            }
         } else {
             print("Error: Could not generate icon.")
         }

--- a/src/ghostsmith.swift
+++ b/src/ghostsmith.swift
@@ -284,6 +284,7 @@ struct GhostSmith {
         var ghostColorString: String?
         var frameString: String?
         var applyIcon: Bool = false
+        var customAppPath: String?
 
         // Parse command line arguments
         let arguments = CommandLine.arguments
@@ -306,6 +307,10 @@ struct GhostSmith {
             case "--apply":
                 applyIcon = true
                 i += 1
+                if i < arguments.count, !arguments[i].hasPrefix("--") {
+                    customAppPath = arguments[i]
+                    i += 1
+                }
             default:
                 i += 1
             }
@@ -339,8 +344,9 @@ struct GhostSmith {
         // Create and save the image
         let iconGenerator = ColorizedGhosttyIcon(screenColors: screenColors, ghostColor: ghostColor, frame: frame)
         if let icon = iconGenerator.makeImage() {
-            if applyIcon {
-                setAppIcon(icon, appPath: "/Applications/Ghostty.app")
+            let appPath = customAppPath ?? "/Applications/Ghostty.app"
+            if applyIcon || customAppPath != nil {
+                setAppIcon(icon, appPath: appPath)
             } else {
                 saveImageAsPNG(image: icon, filename: "custom-icon.png")
             }


### PR DESCRIPTION
When run with the `--apply` flag, ghostsmith will set the application icon directly rather than saving as a PNG to the current working directory. The application path of Ghostty is assumed to be `/Applications/Ghostty.app`.